### PR TITLE
chore: move ariadne codegen to dev dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -176,8 +176,10 @@ version = "0.14.0"
 description = "Generate fully typed GraphQL client from schema, queries and mutations!"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "ariadne_codegen-0.14.0-py2.py3-none-any.whl", hash = "sha256:e0553960bd298ddc49aeeb748a0be3a37acbdfdee7d7c26fce7154715fa826e0"},
+    {file = "ariadne_codegen-0.14.0.tar.gz", hash = "sha256:d5b15470195c3858b88a2bae855b5c04602ffae40228077b6cfb26a57d3f14f6"},
+]
 
 [package.dependencies]
 autoflake = "*"
@@ -193,12 +195,6 @@ toml = ">=0.10,<1.0"
 dev = ["ariadne", "freezegun", "mypy", "pylint", "pytest", "pytest-asyncio", "pytest-httpx", "pytest-mock", "requests-toolbelt", "types-toml"]
 opentelemetry = ["opentelemetry-api"]
 subscriptions = ["websockets (>=11.0,<12.0)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/mirumee/ariadne-codegen.git"
-reference = "11bfe35b"
-resolved_reference = "11bfe35bd62b2489927e0e93c6891bccc29c7f37"
 
 [[package]]
 name = "async-timeout"
@@ -1559,4 +1555,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e8f3140c710672570b0ba86698aa77c445452fe4f74a0a1decd38b1668589d12"
+content-hash = "b3fad0b87ef9d6f0157b44f272526bea28bd08eb02bf50cfcb8e5a312eed0044"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.9.5"
-ariadne-codegen = { git = "https://github.com/mirumee/ariadne-codegen.git", rev = "11bfe35b" }
 pydantic = "^2.0.0"
 python = "^3.9"
 pyyaml = "^6.0.2"
@@ -30,6 +29,7 @@ rich = "^13.3.5"
 typer = "^0.9.0"
 
 [tool.poetry.dev-dependencies]
+ariadne-codegen = "^0.14.0"
 autoflake = "^2.3.1"
 black = "^24.2.0"
 flake8 = "^7.0.0"


### PR DESCRIPTION
Can't use a github repo as a direct dependency: https://github.com/MetaphorData/aesop/actions/runs/11039811849/job/30667275368#step:6:27

Codegen isn't needed for end users, since the generated code is checked into the repo.

We don't need to use the latest commit of ariadne-codegen anymore, the reason why we needed it is because it has fixes for auto generating queries and classes for custom queries that is not released yet. We're handcrafting out queries now, and the hand crafted queries don't have that problem.