### PR TITLE
chore: rename project from aesop to metaphor-aesop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "aesop"
+name = "metaphor-aesop"
 version = "0.0.0"  # Just a placeholder
 description = "A CLI application for Metaphor data ingestion and upload"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Development Status :: 3 - Alpha"
 ]
+packages = [
+    { include = "aesop" },
+]
 
 [tool.poetry.dependencies]
 aiohttp = "^3.9.5"


### PR DESCRIPTION
So then people will do
`pip install metaphor-aesop`

and then when they use it:
`aesop --help`

This is necessary to publish it: https://github.com/MetaphorData/aesop/actions/runs/11040562772/job/30668829288#step:6:27
We can't name our project because the name in pyproject.toml has to be the same as the one specified in pypi, and in pypi there's already a project named aesop.