### PR TITLE
[sc-29178] Help command

### DIFF
--- a/aesop/app.py
+++ b/aesop/app.py
@@ -1,8 +1,12 @@
+import glob
+from enum import Enum
 from importlib import metadata
+from pathlib import Path
 
 import typer
 import yaml
 from rich import print
+from rich.markdown import Markdown
 from typing_extensions import Annotated
 
 from aesop.commands import (
@@ -55,6 +59,32 @@ def version() -> None:
     Print Aesop's version.
     """
     print(f"Aesop version: {metadata.version('aesop')}")
+
+
+root_path = Path(__file__).parents[1].resolve()  # This is the root directory
+commands_path = root_path / "docs" / "commands"
+CommandsWithHelpDoc = Enum(  # type: ignore
+    "CommandsWithHelpDoc",
+    {
+        f"v_{v}": v
+        for v in [
+            filename.split(".", maxsplit=1)[0].split("/")[-1]
+            for filename in glob.glob((commands_path / "*.md").as_posix())
+        ]
+    },
+)
+
+
+@app.command()
+def help(
+    command: CommandsWithHelpDoc,  # type: ignore
+) -> None:
+    """
+    Print help for a command.
+    """
+    command_name: str = command.value
+    with open(commands_path / f"{command_name}.md") as f:
+        print(Markdown(f.read()))
 
 
 @app.callback()

--- a/docs/commands/tags.md
+++ b/docs/commands/tags.md
@@ -1,0 +1,15 @@
+# `aesop tags`
+
+Manages the governed tags in Metaphor.
+
+Available subcommands:
+
+- add
+- batch-add
+- remove
+- batch-remove
+- assign
+- batch-assign
+- unassign
+- batch-unassign
+- get

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ skip_glob = ["aesop/graphql/generated/*"]
 [tool.mypy]
 ignore_missing_imports = true
 strict = true
+warn_unused_ignores = false
 exclude = "aesop/graphql/generated/"
 
 [tool.flake8]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

A `help` command that lists available commands is probably a good thing.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added a `help` command to dynamically display help messages based on what documents are in `docs/commands` directory.

If you enter `aesop help`, it will display a list of available commands that you can get help for:
<img width="1646" alt="截圖 2024-10-04 下午4 44 01" src="https://github.com/user-attachments/assets/2236c5bd-4dfa-4642-9a22-20e8628029f3">

Right now there's only `tags` command that has a help documentation. If you enter `aesop help tags`, it prints the content of `docs/commands/tags.md` on to the console:
<img width="1646" alt="截圖 2024-10-04 下午4 44 18" src="https://github.com/user-attachments/assets/98093df3-9e88-414c-912f-37adbd5af8af">

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

See above.