### PR TITLE
chore: config.yml use full url instead of `config` and `tenant`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 
 env:
   PYTHON_VERSION: 3.9
-  ENVIRONMENT: https://qa.metaphor.io
+  URL: https://qa.metaphor.io
   METAPHOR_API_KEY: meta-03f22b24-faaf-4b0e-9ab7-27e91701a7d1
 
 # Run this build workflow for every new PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 
 env:
   PYTHON_VERSION: 3.9
-  CONFIG: qa
+  ENVIRONMENT: qa
   METAPHOR_API_KEY: meta-03f22b24-faaf-4b0e-9ab7-27e91701a7d1
 
 # Run this build workflow for every new PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 
 env:
   PYTHON_VERSION: 3.9
-  ENVIRONMENT: qa
+  ENVIRONMENT: https://qa.metaphor.io
   METAPHOR_API_KEY: meta-03f22b24-faaf-4b0e-9ab7-27e91701a7d1
 
 # Run this build workflow for every new PR

--- a/README.md
+++ b/README.md
@@ -1,21 +1,13 @@
 # Aesop, the Metaphor CLI Tool
 
-This repository contains a command-line interface (CLI) tool designed for easy interaction with the Metaphor Data platform. The tool currently supports uploading data assets to your Metaphor Data instance.
-
-## Commands
-
-- **Info**: Display information about Metaphor.
-- **Settings**: Manage settings in Metaphor.
-- **Tags**: Manage tags in Metaphor.
-- **Data Asset Uploads**: Upload data assets (knowledge cards) from a structured CSV file.
+This repository contains a command-line interface (CLI) tool designed for easy interaction with the Metaphor Data platform.
 
 ## Config file
 
 The config file should include the following fields:
 
 ```yaml
-config: <CONFIG>
-tenant: <TENANT> # This is only applicable to multi-tenant environments.
+environment: <ENVIRONMENT> # The prefix for the Metaphor app. E.g. for `https://acme.metaphor.io`, use `acme`.
 api_key: <API_KEY>
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains a command-line interface (CLI) tool designed for easy i
 The config file should include the following fields:
 
 ```yaml
-environment: <ENVIRONMENT> # The prefix for the Metaphor app. E.g. for `https://acme.metaphor.io`, use `acme`.
-api_key: <API_KEY>
+url: <URL> # The Metaphor app's URL. E.g. `https://acme.metaphor.io`.
+api_key: <API_KEY> # The api key.
 ```
 
 By default, `aesop` will look for `~/.config/aesop.yml`. You can provide a path to your config file via option `--config-file`.

--- a/aesop/commands/documents/biz_glossary.py
+++ b/aesop/commands/documents/biz_glossary.py
@@ -140,5 +140,5 @@ def import_(
     if not namespace_id:
         print(f"Created {files_created} files.")
     else:
-        namespace_url = config.base_url / "documents" / "directories" / namespace_id
+        namespace_url = config.url / "documents" / "directories" / namespace_id
         print(f"Created {files_created} files: {namespace_url.human_repr()}")

--- a/aesop/config.py
+++ b/aesop/config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 
 import yarl
 from pydantic import BaseModel
@@ -10,14 +9,12 @@ DEFAULT_CONFIG_PATH = Path.home() / ".aesop" / "config.yml"
 
 
 class AesopConfig(BaseModel):
-    config: str
+    environment: str
     api_key: str
-    tenant: Optional[str] = None
 
     @property
     def base_url(self) -> yarl.URL:
-        prefix = f"{self.tenant}.{self.config}" if self.tenant else self.config
-        return yarl.URL(f"https://{prefix}.metaphor.io")
+        return yarl.URL(f"https://{self.environment}.metaphor.io")
 
     def get_graphql_client(self) -> Client:
         return Client(

--- a/aesop/config.py
+++ b/aesop/config.py
@@ -18,7 +18,7 @@ class AesopConfig(BaseModel):
 
     @property
     def url(self) -> yarl.URL:
-        return yarl.URL(self.url_.unicode_string())
+        return yarl.URL(self.url_.scheme + "://" + (self.url_.unicode_host() or ""))
 
     def get_graphql_client(self) -> Client:
         # yarl does not care if there's a trailing slash, pydantic url does

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def config_file(
         _user_config
         if _user_config
         else AesopConfig(
-            url=Url(url=os.environ.get("url", "")),
+            url=Url(url=os.environ.get("URL", "")),
             api_key=os.environ.get("METAPHOR_API_KEY", ""),
         )
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import typing
 import loguru
 import pytest
 import yaml
+from pydantic_core import Url
 
 from aesop.config import DEFAULT_CONFIG_PATH, AesopConfig
 
@@ -29,12 +30,12 @@ def config_file(
         _user_config
         if _user_config
         else AesopConfig(
-            environment=os.environ.get("ENVIRONMENT", ""),
+            url=Url(url=os.environ.get("url", "")),
             api_key=os.environ.get("METAPHOR_API_KEY", ""),
         )
     )
     loguru.logger.info(f"Config = {config}")
     path = tmp_path_factory.mktemp("config") / "config.yml"
     with open(path, "w") as file:
-        file.write(yaml.safe_dump(config.model_dump()))
+        file.write(yaml.safe_dump(config.model_dump(by_alias=True)))
     return path.as_posix()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,8 @@ def config_file(
         _user_config
         if _user_config
         else AesopConfig(
-            config=os.environ.get("CONFIG", ""),
+            environment=os.environ.get("ENVIRONMENT", ""),
             api_key=os.environ.get("METAPHOR_API_KEY", ""),
-            tenant=os.environ.get("TENANT"),
         )
     )
     loguru.logger.info(f"Config = {config}")


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`config` and `tenant` is confusing to people outside of the Metaphor team. The full URL is simpler to understand.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Updated aesop config to expect a single `url` field instead of both `config` and `tenant`.
- Updated tests.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Updated tests and tested locally.