### PR TITLE
[sc-29511] Use `metaphor-aesop` as package name

### DIFF
--- a/aesop/app.py
+++ b/aesop/app.py
@@ -62,7 +62,7 @@ def version() -> None:
     """
     Print Aesop's version.
     """
-    print(f"Aesop version: {metadata.version('aesop')}")
+    print(f"Aesop version: {metadata.version('metaphor-aesop')}")
 
 
 root_path = Path(__file__).parent.resolve()  # This is the aesop app directory


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Our tool's package name is `metaphor-aesop`, not `aesop`. In `aesop version` we should use `metaphor-aesop` so that it resolves to the correct package.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

`aesop` -> `metaphor-aesop`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Before:

<img width="1710" alt="截圖 2024-10-23 晚上7 36 53" src="https://github.com/user-attachments/assets/c1d0cea3-ca3f-4a53-9b78-33455124e241">

After:

<img width="1710" alt="截圖 2024-10-23 晚上7 34 53" src="https://github.com/user-attachments/assets/9615b4b7-95be-4664-a361-e12cae4d58bc">
