### PR TITLE
chore: simple command to create data document

### DIFF
--- a/aesop/app.py
+++ b/aesop/app.py
@@ -11,6 +11,7 @@ from typing_extensions import Annotated
 
 from aesop.commands import (
     datasets_app,
+    documents_app,
     domains_app,
     glossaries_app,
     info_command,
@@ -25,6 +26,7 @@ from aesop.config import DEFAULT_CONFIG_PATH, AesopConfig
 
 app = typer.Typer(add_completion=False, rich_markup_mode="markdown")
 app.add_typer(datasets_app, name="datasets")
+app.add_typer(documents_app, name="documents")
 app.add_typer(domains_app, name="domains")
 app.add_typer(glossaries_app, name="glossaries")
 app.add_typer(settings_app, name="settings")

--- a/aesop/commands/__init__.py
+++ b/aesop/commands/__init__.py
@@ -1,4 +1,5 @@
 from .aspects import tags_app
+from .documents.documents import app as documents_app
 from .documents.glossaries import app as glossaries_app
 from .domains.domains import app as domains_app
 from .entities import datasets_app
@@ -9,6 +10,7 @@ from .webhooks import app as webhooks_app
 
 __all__ = [
     "datasets_app",
+    "documents_app",
     "domains_app",
     "glossaries_app",
     "info_command",

--- a/aesop/commands/documents/documents.py
+++ b/aesop/commands/documents/documents.py
@@ -1,0 +1,25 @@
+from rich import print
+from typer import Context, Typer
+
+from aesop.commands.common.exception_handler import exception_handler
+from aesop.config import AesopConfig
+
+app = Typer()
+
+
+@exception_handler("create document")
+@app.command(help="Creates a data document.")
+def create(
+    ctx: Context,
+    name: str,
+    content: str,
+) -> None:
+    config: AesopConfig = ctx.obj
+    resp = (
+        config.get_graphql_client()
+        .create_data_document(name=name, content=content, publish=True)
+        .create_knowledge_card
+    )
+    assert resp
+    url = config.url / "document" / resp.id.split("~", maxsplit=1)[-1]
+    print(f"Created document: {url.human_repr()}")


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Uploading document via API is hard to do by hand, might as well make a simple CLI command for it.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Simple CLI command to upload a single data document to Metaphor.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested on andy.dev.metaphor.io.

The command:
<img width="1648" alt="截圖 2024-10-31 凌晨12 07 08" src="https://github.com/user-attachments/assets/a57c00c3-9a57-4e10-8e64-a81ebcfdc2db">

Creating the document:
<img width="1648" alt="截圖 2024-10-31 凌晨12 08 54" src="https://github.com/user-attachments/assets/e953e635-4d0d-4d4e-9078-a9df3a829ae9">

The created document:
<img width="1710" alt="截圖 2024-10-31 凌晨12 09 15" src="https://github.com/user-attachments/assets/9248f898-aad0-446a-bed3-e2b24538772f">

### TODO

- Attach the document to a namespace
- Governed tags, contacts