### PR TITLE
[sc-28951] Action to downlaod `schema.gql` and check it into the repo

### DIFF
--- a/.github/workflows/update_api_schema.yml
+++ b/.github/workflows/update_api_schema.yml
@@ -1,0 +1,71 @@
+---
+name: Fetch Schema and Create PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: false
+        default: ''
+  repository_dispatch:
+    types: [upload-api-schema]
+
+jobs:
+  update-api-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set run_id
+        id: set_run_id
+        run: |
+          # Check if run_id is provided via inputs (manual trigger)
+          if [ "${{ github.event.inputs.run_id }}" != "" ]; then
+            echo "run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_ENV
+          # Check if run_id is in repository_dispatch payload (auto trigger)
+          elif [ "${{ github.event.client_payload.run_id }}" != "" ]; then
+            echo "run_id=${{ github.event.client_payload.run_id }}" >> $GITHUB_ENV
+          else
+            echo "No run_id provided. Exiting."
+            exit 1
+          fi
+
+      - name: Download API schema artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: api-schema
+          github-token: ${{ github.token }}
+          repository: MetaphorData/app
+          run-id: ${{ env.run_id }}
+          # Replace with the correct run ID or workflow run name to target the artifact location if needed.
+
+      - name: Move schema to desired location
+        run: |
+          mv api-schema schema.gql
+
+      - name: Commit changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add schema.gql
+          git commit -m "Update schema.gql from upstream"
+
+      - name: Push changes to a new branch
+        run: |
+          git push origin HEAD:refs/heads/update-api-schema
+
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        with:
+          script: |-
+            const { context, github } = require('@actions/github');
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Update schema.gql",
+              head: "update-api-schema",
+              base: "main",
+              body: "Automated update of schema.gql from upstream repository."
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-schema.gql
 **/__pycache__
 .pytest_cache
 .vscode


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

We need to have the latest API schema in order to make sure codegen isn't targeting outdated schema. In order to do that, the Metaphor app repo will upload the latest API schema as a GH artifact, and here we need to download it.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added a GH action that is triggered by:
1. Manually, with a `run_id` as input
2. By the workflow implemented in https://github.com/MetaphorData/app/pull/9759.

This action also creates a PR to check the downloaded `schema.gql` into the repo.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Not yet, no artifact has been uploaded yet.